### PR TITLE
MNT dont pervert BUILD if state_setter is specified

### DIFF
--- a/Lib/pickle.py
+++ b/Lib/pickle.py
@@ -660,16 +660,19 @@ class _Pickler:
                 write(BUILD)
             else:
                 # If a state_setter is specified, call it instead of load_build
-                # to update obj's with its previous state.  The first 4
-                # save/write instructions push state_setter and its tuple of
-                # expected arguments (obj, state) onto the stack. The REDUCE
-                # opcode triggers the state_setter(obj, state) function call.
-                # Finally, because state-updating routines only do in-place
-                # modification, the whole operation has to be
-                # stack-transparent.  Thus, we finally pop the call's output
-                # from the stack.
-                save(state_setter), save(obj), save(state), write(TUPLE2)
+                # to update obj's with its previous state.
+                # First, push state_setter and its tuple of expected arguments
+                # (obj, state) onto the stack.
+                save(state_setter)
+                save(obj)
+                save(state)
+                write(TUPLE2)
+                # Trigger a state_setter(obj, state) function call.
                 write(REDUCE)
+                # The purpose of state_setter is to carry-out an
+                # inplace modification of obj. We do not care about what the
+                # method might return, so its output is eventually removed from
+                # the stack.
                 write(POP)
 
     # Methods below this point are dispatched through the dispatch table

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -3005,7 +3005,6 @@ def setstate_bbb(obj, state):
     classes/functions.
     """
     obj.a = 'foo'
-    return obj
 
 class AbstractDispatchTableTests(unittest.TestCase):
 

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -3005,7 +3005,7 @@ def setstate_bbb(obj, state):
     classes/functions.
     """
     obj.a = 'foo'
-
+    return obj
 
 class AbstractDispatchTableTests(unittest.TestCase):
 

--- a/Lib/test/pickletester.py
+++ b/Lib/test/pickletester.py
@@ -3006,6 +3006,7 @@ def setstate_bbb(obj, state):
     """
     obj.a = 'foo'
 
+
 class AbstractDispatchTableTests(unittest.TestCase):
 
     def test_default_dispatch_table(self):

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -3946,12 +3946,12 @@ save_reduce(PicklerObject *self, PyObject *args, PyObject *obj)
         else {
             const char tupletwo_op = TUPLE2;
             const char pop_op = POP;
-            if (_Pickler_Write(self, &pop_op, 1) < 0 ||
-                save(self, state_setter, 0) < 0 ||
+            if (save(self, state_setter, 0) < 0 ||
                 save(self, obj, 0) < 0 ||
                 save(self, state, 0) < 0 ||
                 _Pickler_Write(self, &tupletwo_op, 1) < 0 ||
-                _Pickler_Write(self, &reduce_op, 1) < 0)
+                _Pickler_Write(self, &reduce_op, 1) < 0 ||
+                _Pickler_Write(self, &pop_op, 1) < 0)
                 return -1;
         }
     }

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -6261,27 +6261,6 @@ load_build(UnpicklerObject *self)
         Py_INCREF(slotstate);
         Py_DECREF(tmp);
     }
-    /* state can embed a callable state setter */
-    else if (PyTuple_Check(state) && PyTuple_GET_SIZE(state) == 3) {
-        PyObject *state_slotstate;
-
-        setstate = PyTuple_GET_ITEM(state, 0);
-        state_slotstate = PyTuple_GetSlice(state, 1, 3);
-
-        Py_INCREF(setstate);
-
-        /* call the setstate function */
-        if (PyObject_CallFunctionObjArgs(setstate, inst, state_slotstate,
-                                         NULL) == NULL){
-            Py_DECREF(state_slotstate);
-            Py_DECREF(setstate);
-            return -1;
-        }
-
-        Py_DECREF(state_slotstate);
-        Py_DECREF(setstate);
-        return 0;
-    }
     else
         slotstate = NULL;
 

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -3946,8 +3946,7 @@ save_reduce(PicklerObject *self, PyObject *args, PyObject *obj)
         else {
             const char tupletwo_op = TUPLE2;
             const char pop_op = POP;
-            if (
-                _Pickler_Write(self, &pop_op, 1) < 0 ||
+            if (_Pickler_Write(self, &pop_op, 1) < 0 ||
                 save(self, state_setter, 0) < 0 ||
                 save(self, obj, 0) < 0 ||
                 save(self, state, 0) < 0 ||

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -3944,11 +3944,20 @@ save_reduce(PicklerObject *self, PyObject *args, PyObject *obj)
                 return -1;
         }
         else {
+
+            /* If a state_setter is specified, call it instead of load_build to
+             * update obj's with its previous state.
+             * The first 4 save/write instructions push state_setter and its
+             * tuple of expected arguments (obj, state) onto the stack. The
+             * REDUCE opcode triggers the state_setter(obj, state) function
+             * call. Finally, because state-updating routines only do in-place
+             * modification, the whole operation has to be stack-transparent.
+             * Thus, we finally pop the call's output from the stack.*/
+
             const char tupletwo_op = TUPLE2;
             const char pop_op = POP;
             if (save(self, state_setter, 0) < 0 ||
-                save(self, obj, 0) < 0 ||
-                save(self, state, 0) < 0 ||
+                save(self, obj, 0) < 0 || save(self, state, 0) < 0 ||
                 _Pickler_Write(self, &tupletwo_op, 1) < 0 ||
                 _Pickler_Write(self, &reduce_op, 1) < 0 ||
                 _Pickler_Write(self, &pop_op, 1) < 0)

--- a/Modules/_pickle.c
+++ b/Modules/_pickle.c
@@ -3944,40 +3944,17 @@ save_reduce(PicklerObject *self, PyObject *args, PyObject *obj)
                 return -1;
         }
         else {
-            PyObject *statetup = NULL;
-
-            /* If a state_setter is specified, and state is a dict, we could be
-             * tempted to save a (state_setter, state) as state, but this would
-             * collide with load_build's (state, slotstate) special handling.
-             * Therefore, create a new format for state saving: (state_setter,
-             * state, slotstate)
-             */
-            if PyDict_Check(state)
-                statetup = Py_BuildValue("(OOO)", state_setter, state,
-                                         Py_None);
-            else if PyTuple_Check(state) {
-                if (PyTuple_GET_SIZE(state) == 2) {
-                    statetup = Py_BuildValue("(OOO)", state_setter,
-                                             PyTuple_GetItem(state, 0),
-                                             PyTuple_GetItem(state, 1));
-                }
-            }
-
-            if (statetup == NULL) {
-                PyErr_SetString(st->PicklingError,
-                                "state must be either a dict or a tuple of"
-                                " length 2");
+            const char tupletwo_op = TUPLE2;
+            const char pop_op = POP;
+            if (
+                _Pickler_Write(self, &pop_op, 1) < 0 ||
+                save(self, state_setter, 0) < 0 ||
+                save(self, obj, 0) < 0 ||
+                save(self, state, 0) < 0 ||
+                _Pickler_Write(self, &tupletwo_op, 1) < 0 ||
+                _Pickler_Write(self, &reduce_op, 1) < 0)
                 return -1;
-            }
-
-            if (save(self, statetup, 0) < 0 ||
-                _Pickler_Write(self, &build_op, 1) < 0) {
-                Py_DECREF(statetup);
-                return -1;
-            }
-            Py_DECREF(statetup);
         }
-
     }
     return 0;
 }


### PR DESCRIPTION
@ogrisel @pitrou @ncoghlan here is another way of saving an object with a custom `state_setter`. 
This is more compact than the other option, and has the advantage of being fully backward compatible, but it involves some Unpickler stack manipulation:

stack before the state handling part of `save_reduce`
(1) `[..., obj]`

if `state_setter is not None`, we write state_setter and its args, with the resulting stack

(2) `[..., obj, state_setter, (obj, state)]`

after `state_setter` is called, the stack is 
(3) `[..., obj, state_setter(obj, state)]`

and we finally have to discard the top of stack (as `state_setter`'s purpose is to do in-place modification of `obj`), by writing a POP opcode.

WDYT?